### PR TITLE
fix-logger

### DIFF
--- a/LightAgent/la_core.py
+++ b/LightAgent/la_core.py
@@ -1461,11 +1461,13 @@ class LightSwarm:
         for agent in agents:
             if agent.name in self.agents:
                 # print(f"Agent '{agent.name}' is already registered.")
-                agent.logger.log("INFO", "register_agent", {"agent_name": agent.name, "status": "already_registered"})
+                if hasattr(agent, 'logger') and agent.debug:
+                    agent.logger.log("INFO", "register_agent", {"agent_name": agent.name, "status": "already_registered"})
             else:
                 self.agents[agent.name] = agent
                 # print(f"Agent '{agent.name}' registered.")
-                agent.logger.log("INFO", "register_agent", {"agent_name": agent.name, "status": "registered"})
+                if hasattr(agent, 'logger') and agent.debug:
+                    agent.logger.log("INFO", "register_agent", {"agent_name": agent.name, "status": "registered"})
 
     def run(self, agent: LightAgent, query: str, stream=False):
         """


### PR DESCRIPTION
在 LightAgent 类的构造函数中，logger 属性只在 debug 参数为 True 时才会被初始化，但是在 LightSwarm 类的 register_agent 方法中，无论 debug 模式是否开启，都会尝试访问 agent.logger 属性，这导致了当以非 debug 模式创建 LightAgent 实例并在 LightSwarm 中注册时会出现 AttributeError 错误