### PR TITLE
fix: TypeError when initializing LightAgent with debug=True and no log_file

### DIFF
--- a/LightAgent/la_core.py
+++ b/LightAgent/la_core.py
@@ -548,6 +548,8 @@ class LightAgent:
             os.makedirs(log_dir)
         # 将 log_file 路径设置为 log 目录下的文件
         if debug:
+            if not log_file:
+                log_file = f"{self.name}.log"
             self.log_file = os.path.join(log_dir, log_file)
             # Set up the logger
             # 初始化日志系统
@@ -555,7 +557,7 @@ class LightAgent:
                 name=self.name,
                 debug=debug,
                 log_level=log_level,
-                log_file=log_file
+                log_file=self.log_file
             )
 
         if tools is None:


### PR DESCRIPTION
## Problem

When a user creates a `LightAgent` with `debug=True` but does not specify `log_file`, the constructor crashes with:

```
TypeError: expected str, bytes or os.PathLike object, not NoneType
```

This is because `os.path.join('logs', None)` is called when `log_file` defaults to `None`.

```python
# This crashes
agent = LightAgent(model="gpt-4o-mini", api_key="sk-xxx", debug=True)
```

## Root Cause

In `LightAgent.__init__`, the `debug=True` branch unconditionally calls `os.path.join(log_dir, log_file)` without checking for `None`.

## Fix

- Default `log_file` to `{agent_name}.log` when `debug=True` and no `log_file` is provided.
- Pass the fully resolved path (`self.log_file`) to `LoggerManager` instead of the raw `log_file` parameter, ensuring the log file is written to the correct `logs/` directory.