### PR TITLE
fix: prevent KeyError in `get_history()` when called before `run()`

### DIFF
--- a/LightAgent/la_core.py
+++ b/LightAgent/la_core.py
@@ -619,7 +619,7 @@ class LightAgent:
         """
         获取对话的history的描述（OpenAI 格式）
         """
-        return deepcopy(self.chat_params['messages'])
+        return deepcopy(self.chat_params.get('messages', []))
 
     def get_tools(self) -> List[Dict[str, Any]]:
         """


### PR DESCRIPTION
### Problem

`get_history()` raises a `KeyError: 'messages'` when called before `run()`.

`self.chat_params` is initialized as an empty dict `{}` in `__init__`, and the `messages` key is only populated once `run()` is invoked. Any call to `get_history()` prior to `run()` results in an unhandled `KeyError`.

**Reproduction:**

```python
from LightAgent import LightAgent

agent = LightAgent(
    model="gpt-4o-mini",
    api_key="test_key",
    base_url="http://localhost:8000/v1"
)

history = agent.get_history()  # KeyError: 'messages'
```

### Solution

Replace the direct dict key access `self.chat_params['messages']` with `self.chat_params.get('messages', [])` in `get_history()`, so it returns an empty list instead of raising a `KeyError` when called before `run()`.