### PR TITLE
fix: handle P0 issues

### DIFF
--- a/LightAgent/core.py
+++ b/LightAgent/core.py
@@ -179,47 +179,44 @@ class LightAgent:
         self.skills_directories = skills_directories or ["skills"]
         self.skill_manager = SkillManager(self.skills_directories, self.logger if debug else None)
 
-        if tools is None:
-            self.tools = []
-        if tools is not None:
-            # 初始化工具列表
-            self.tools = tools
-            self.load_tools(tools)
-            # 自动注册内置工具
-            builtin_tools = [
-                execute_python_code,
-                execute_python_file,
-                execute_python_code_stream,
-                upload_file_to_oss
-            ]
+        self.tools = tools or []
+        if self.tools:
+            self.load_tools(self.tools)
 
-            for tool_func in builtin_tools:
+        # 自动注册内置工具
+        builtin_tools = [
+            execute_python_code,
+            execute_python_file,
+            execute_python_code_stream,
+            upload_file_to_oss
+        ]
+
+        for tool_func in builtin_tools:
+            self.tool_registry.register_tool(tool_func)
+            self.loaded_tools[tool_func.tool_info["tool_name"]] = tool_func
+
+        if debug:
+            self.log("INFO", "builtin_tools_loaded",
+                     {"count": len(builtin_tools), "tools": [f.tool_info["tool_name"] for f in builtin_tools]})
+
+        # 自动发现skill技能
+        if auto_discover_skills:
+            discovered = self.skill_manager.discover_skills()
+            if debug and discovered:
+                self.log("INFO", "skills_discovered",
+                         {"count": len(discovered), "skills": [s.name for s in discovered]})
+        # 自动加载自带的skill相关的系统级工具
+        if auto_discover_skills and self.skill_manager.skills:
+            skill_tools = create_skill_tools(self.skill_manager)
+            for tool_func in skill_tools:
                 self.tool_registry.register_tool(tool_func)
                 self.loaded_tools[tool_func.tool_info["tool_name"]] = tool_func
-
             if debug:
-                self.log("INFO", "builtin_tools_loaded",
-                         {"count": len(builtin_tools), "tools": [f.tool_info["tool_name"] for f in builtin_tools]})
+                self.log("INFO", "skill_tools_loaded",
+                         {"count": len(skill_tools), "tools": [f.tool_info["tool_name"] for f in skill_tools]})
 
-            # 自动发现skill技能
-            if auto_discover_skills:
-                discovered = self.skill_manager.discover_skills()
-                if debug and discovered:
-                    self.log("INFO", "skills_discovered",
-                             {"count": len(discovered), "skills": [s.name for s in discovered]})
-            # 自动加载自带的skill相关的系统级工具
-            if auto_discover_skills and self.skill_manager.skills:
-                skill_tools = create_skill_tools(self.skill_manager)
-                for tool_func in skill_tools:
-                    self.tool_registry.register_tool(tool_func)
-                    self.loaded_tools[tool_func.tool_info["tool_name"]] = tool_func
-                if debug:
-                    self.log("INFO", "skill_tools_loaded",
-                             {"count": len(skill_tools), "tools": [f.tool_info["tool_name"] for f in skill_tools]})
-
-            print("self.tool_registry.function_mappings", self.tool_registry.function_mappings)
-            self.tool_dispatcher = AsyncToolDispatcher(self.tool_registry.function_mappings)
-            # register_tool_manually(tools)
+        self.tool_dispatcher = AsyncToolDispatcher(self.tool_registry.function_mappings)
+        # register_tool_manually(tools)
 
         if api_key is None:
             raise ValueError(
@@ -453,20 +450,24 @@ class LightAgent:
         :param tools: 运行时传入的工具列表
         :return: OpenAI格式的工具描述列表
         """
-        runtime_tools = []
         temp_registry = ToolRegistry()
 
         for tool in tools:
             if isinstance(tool, str):
                 try:
                     tool_func = self.tool_loader.load_tool(tool)
-                    temp_registry.register_tool(tool_func)
+                    if temp_registry.register_tool(tool_func):
+                        self.tool_registry.register_tool(tool_func)
+                        self.loaded_tools[tool_func.tool_info["tool_name"]] = tool_func
                 except Exception as e:
                     self.log("ERROR", "load_runtime_tool", {"tool": tool, "error": str(e)})
             elif callable(tool) and hasattr(tool, "tool_info"):
-                temp_registry.register_tool(tool)
+                if temp_registry.register_tool(tool):
+                    self.tool_registry.register_tool(tool)
+                    self.loaded_tools[tool.tool_info["tool_name"]] = tool
 
         runtime_tools = temp_registry.get_tools()
+        self.tool_dispatcher = AsyncToolDispatcher(self.tool_registry.function_mappings)
         self.log("DEBUG", "runtime_tools_processed", {"count": len(runtime_tools)})
         return runtime_tools
 

--- a/LightAgent/tools.py
+++ b/LightAgent/tools.py
@@ -58,6 +58,10 @@ class ToolRegistry:
             }
         }
 
+        self.openai_function_schemas = [
+            schema for schema in self.openai_function_schemas
+            if schema.get("function", {}).get("name") != tool_name
+        ]
         self.openai_function_schemas.append(tool_def_openai)
         return True
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ This page is docs-only and does not change any framework code.
 
 For common installation, model provider, tool, memory, MCP, Skills, streaming, and LightSwarm questions, see [FAQ](docs/FAQ.md).
 
+For shared long-term memory or graph memory deployments, review the [Memory Security Guidance](docs/memory_security.md).
+
 ---
 
 ## 🚧 Coming Soon

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -96,6 +96,8 @@ The public API accepts `run(..., tools=[...])`, but runtime tool dispatch needs 
 
 LightAgent accepts a custom memory object through the `memory` parameter. The object should provide `store(data, user_id)` and `retrieve(query, user_id)` methods. The README includes a Mem0-based example, and other memory backends can be integrated by implementing the same small interface.
 
+For shared or graph-backed memory deployments, review the [Memory Security Guidance](memory_security.md) before enabling cross-user persistence.
+
 ### What is Tree of Thought?
 
 Tree of Thought is an optional planning and reflection mode enabled with `tree_of_thought=True`. It uses a reasoning model to create a tool-use plan and can filter tools before the final model call.

--- a/docs/memory_security.md
+++ b/docs/memory_security.md
@@ -1,0 +1,65 @@
+## Memory Security Guidance
+
+LightAgent accepts external memory backends through a small `store()` and
+`retrieve()` interface. This keeps the framework flexible, but it also means
+deployments must treat long-term memory as a trust boundary.
+
+### Threat Model
+
+Shared memory backends can persist user supplied content and later return it as
+agent context. If untrusted content is written into the same memory namespace as
+trusted content, a later request can retrieve poisoned facts and pass them to the
+model as apparently reliable context.
+
+This is especially important for high-impact domains such as healthcare,
+finance, legal, enterprise automation, and policy support.
+
+### Recommended Defaults
+
+- Use separate memory namespaces per user, tenant, agent, and environment.
+- Do not share graph memory across users unless there is an explicit product
+  requirement and a reviewable access policy.
+- Treat retrieved memories as untrusted context unless the memory backend can
+  provide provenance and trust metadata.
+- Disable memory writes for high-impact workflows until source trust,
+  consistency checks, and rollback behavior are defined.
+- Log memory writes at the metadata level: user id, agent id, source, timestamp,
+  and trust level. Avoid logging sensitive raw content unless required by your
+  compliance process.
+
+### Admission Checks Before Writing Memory
+
+Memory adapters should validate candidate memories before persistence:
+
+- Record provenance: source user, agent, tool, channel, and timestamp.
+- Keep trust levels separate, for example system, admin, verified source,
+  authenticated user, and unauthenticated user.
+- Reject or quarantine memories that contradict higher-trust facts.
+- Avoid merging entities only by similar names; include entity type, context,
+  tenant, and relation neighborhood in entity resolution.
+- Preserve conflicting facts with provenance instead of silently deleting older
+  trusted facts.
+
+### Retrieval Checks Before Using Memory
+
+Before injecting retrieved memory into the model context:
+
+- Filter by tenant, user, agent, and allowed source trust level.
+- Prefer verified or same-user memories over cross-user memories.
+- Include provenance in internal context where possible.
+- For high-impact answers, require a trusted external source or tool result
+  before producing recommendations.
+
+### Mem0 Graph Memory Notes
+
+When using Mem0 graph memory or another shared graph backend, configure it so
+one user's conversational claims cannot overwrite or remove trusted facts for
+another user. If the backend cannot enforce that policy, use isolated memory
+instances or per-user namespaces.
+
+### LightAgent Adapter Guidance
+
+Custom memory implementations passed to `LightAgent(memory=...)` should enforce
+the security policy inside their `store()` and `retrieve()` methods. LightAgent
+will call those methods, but the backend adapter is responsible for persistence,
+isolation, provenance, and conflict handling.


### PR DESCRIPTION
## Summary
- fix runtime tools dispatch when constructor tools are omitted
- initialize tool_dispatcher unconditionally and register runtime tools into the active registry
- prevent duplicate tool schemas when a tool is re-registered
- add memory security guidance for shared and graph-backed memory deployments

## Verification
- python3 -m compileall -q LightAgent
- runtime dispatch assertion using the Langchain-Chatchat Python environment

Fixes #36.
Duplicate: #35.
Mitigates #39 with initial memory security guidance.