### PR TITLE
fix: assign self.tracetools and add LiteLLM provider docs

### DIFF
--- a/LightAgent/core.py
+++ b/LightAgent/core.py
@@ -262,6 +262,7 @@ class LightAgent:
 
         # 初始化客户端
         self._initialize_clients(tracetools, tot_api_key, tot_base_url, tot_model)
+        self.tracetools = tracetools
         self.chat_params = {}  # history 存储器
         self._trace_recorder = TraceRecorder(enabled=False)
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -37,7 +37,7 @@ print(response)
 
 ### Which model providers are supported?
 
-LightAgent can use OpenAI-compatible chat completion endpoints. The README examples cover OpenAI, DeepSeek, Qwen, Zhipu ChatGLM, Baichuan, StepFun, and other compatible providers. For OpenRouter or a self-hosted gateway, set `base_url` to the provider's OpenAI-compatible endpoint. See [Model Provider Configuration](model_providers.md) for OpenRouter, vLLM, llama.cpp, and Ollama examples.
+LightAgent can use OpenAI-compatible chat completion endpoints. The README examples cover OpenAI, DeepSeek, Qwen, Zhipu ChatGLM, Baichuan, StepFun, and other compatible providers. For OpenRouter or a self-hosted gateway, set `base_url` to the provider's OpenAI-compatible endpoint. For multi-provider routing through a single SDK, use `provider="litellm"` with the optional `LightAgent[litellm]` dependency. See [Model Provider Configuration](model_providers.md) for OpenRouter, vLLM, llama.cpp, Ollama, and LiteLLM examples.
 
 Example OpenRouter configuration:
 

--- a/docs/model_providers.md
+++ b/docs/model_providers.md
@@ -76,6 +76,51 @@ agent = LightAgent(
 )
 ```
 
+### LiteLLM (multi-provider routing)
+
+LiteLLM provides a unified interface to 100+ LLM providers through a single SDK.
+LightAgent supports LiteLLM as an optional provider backend via the `provider`
+parameter. When you pass `provider="litellm"`, all chat completion calls are
+routed through the LiteLLM SDK instead of the default OpenAI client.
+
+**Installation**
+
+```bash
+pip install "LightAgent[litellm]"
+```
+
+**Usage**
+
+```python
+from LightAgent import LightAgent
+
+agent = LightAgent(
+    model="gpt-4.1",
+    provider="litellm",
+    api_key="your_api_key",
+)
+```
+
+When `provider` is set to `"litellm"`, LightAgent creates a `LiteLLMClient`
+wrapper that exposes the same `client.chat.completions.create(**params)`
+interface. You can use any model name that LiteLLM supports, including models
+from Anthropic, Google, Azure, AWS Bedrock, Together AI, and more, without
+changing your code.
+
+**Model routing**
+
+- `model` can be any LiteLLM-supported model string (e.g. `"claude-sonnet-4-20250514"`,
+  `"gemini/gemini-2.5-flash"`, `"together_ai/meta-llama/Llama-4-70B"`).
+- `api_key` and `base_url` are forwarded to the LiteLLM completion call as
+  `api_key` and `api_base` respectively. If `base_url` is the default
+  `https://api.openai.com/v1`, it is omitted so LiteLLM can use its built-in
+  provider routing.
+- The `drop_params` flag is enabled to allow provider-specific parameters to be
+  safely ignored when they do not apply to the target provider.
+
+For a full list of supported models and providers, see the
+[LiteLLM documentation](https://docs.litellm.ai/docs/providers).
+
 ### Troubleshooting
 
 - If you see `[LA-401]`, check the API key or provider account.


### PR DESCRIPTION
## Summary

Two changes:

1. **Bugfix**: Assign  in  so the Langfuse  assignment at line 515 is no longer dead code. Previously, the  accepted a  parameter and passed it to , but never stored it as an instance attribute. The  check was always , so the Langfuse session tracking was silently disabled.

2. **Docs**: Add LiteLLM provider documentation to  covering installation (), usage (), and model routing behavior (model naming, api_key/base_url forwarding, drop_params). Also update  to mention the optional  provider in the supported providers section.

## Test Plan
- Verified  attribute is now properly assigned in the agent instance after initialization
- Confirmed the  check at line 516 is now reachable
- Docs follow the same format as existing provider documentation (OpenRouter, vLLM, llama.cpp, Ollama)
- Python compilation check passes () with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)