### PR TITLE
fix: handle standard logger in skill manager

### DIFF
--- a/LightAgent/skills.py
+++ b/LightAgent/skills.py
@@ -211,17 +211,17 @@ class SkillManager:
         if not self.logger:
             return
 
-        # 检查是否是LightAgent的LoggerManager
-        if hasattr(self.logger, 'log') and callable(getattr(self.logger, 'log')):
-            # 使用LoggerManager的log方法
+        from .logger import LoggerManager
+
+        if isinstance(self.logger, LoggerManager):
             self.logger.log(level, action, data)
         elif hasattr(self.logger, 'debug') and hasattr(self.logger, 'info') and hasattr(self.logger, 'error'):
-            # 使用标准logging.Logger
             log_msg = f"[SkillManager] {action}: {data}"
-            if level == "DEBUG":
-                self.logger.debug(log_msg)
-            elif level == "INFO":
-                self.logger.info(log_msg)
-            elif level == "ERROR":
-                self.logger.error(log_msg)
+            level_map = {
+                "DEBUG": logging.DEBUG,
+                "INFO": logging.INFO,
+                "WARNING": logging.WARNING,
+                "ERROR": logging.ERROR,
+            }
+            self.logger.log(level_map.get(level, logging.INFO), log_msg)
         # 如果没有合适的logger，忽略日志

--- a/tests/test_skill_manager_logging.py
+++ b/tests/test_skill_manager_logging.py
@@ -1,0 +1,80 @@
+import logging
+
+from LightAgent import LightAgent
+from LightAgent.logger import LoggerManager
+from LightAgent.skills import SkillManager
+
+
+def write_skill(skills_dir, name="demo", description="Demo skill"):
+    skill_dir = skills_dir / name
+    skill_dir.mkdir(parents=True)
+    skill_dir.joinpath("SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: {description}\n---\n\nUse the demo skill.\n",
+        encoding="utf-8",
+    )
+    return skill_dir
+
+
+def test_discover_skills_uses_standard_logging_logger_without_type_error(tmp_path, caplog):
+    skills_dir = tmp_path / "skills"
+    write_skill(skills_dir)
+    logger = logging.getLogger("lightagent.test.skillmanager")
+
+    manager = SkillManager([str(skills_dir)], logger=logger)
+
+    with caplog.at_level(logging.DEBUG, logger=logger.name):
+        discovered = manager.discover_skills()
+
+    assert [skill.name for skill in discovered] == ["demo"]
+    assert "discover_skill" in caplog.text
+
+
+def test_lightagent_init_auto_discovers_skills_with_default_logger(tmp_path, monkeypatch):
+    skills_dir = tmp_path / "skills"
+    write_skill(skills_dir)
+    monkeypatch.chdir(tmp_path)
+
+    agent = LightAgent(
+        model="deepseek-v4-flash",
+        api_key="sk-test",
+        base_url="https://api.example.test/v1",
+        skills_directories=[str(skills_dir)],
+    )
+
+    assert "demo" in agent.skill_manager.skills
+
+
+def test_discover_skills_logs_errors_with_standard_logging_logger(tmp_path, caplog):
+    skills_dir = tmp_path / "skills"
+    bad_skill_dir = skills_dir / "bad"
+    bad_skill_dir.mkdir(parents=True)
+    bad_skill_dir.joinpath("SKILL.md").write_text(
+        "---\nname: bad\n---\n\nMissing required description.\n",
+        encoding="utf-8",
+    )
+    logger = logging.getLogger("lightagent.test.skillmanager.error")
+
+    manager = SkillManager([str(skills_dir)], logger=logger)
+
+    with caplog.at_level(logging.ERROR, logger=logger.name):
+        discovered = manager.discover_skills()
+
+    assert discovered == []
+    assert "discover_skill_failed" in caplog.text
+    assert "Skill missing required fields" in caplog.text
+
+
+def test_log_keeps_logger_manager_signature():
+    class CapturingLogger(LoggerManager):
+        def __init__(self):
+            self.calls = []
+
+        def log(self, level, action, data):
+            self.calls.append((level, action, data))
+
+    logger = CapturingLogger()
+    manager = SkillManager([], logger=logger)
+
+    manager._log("DEBUG", "discover_skill", {"name": "demo"})
+
+    assert logger.calls == [("DEBUG", "discover_skill", {"name": "demo"})]


### PR DESCRIPTION
## Summary
- fix SkillManager._log so standard logging.Logger no longer enters the LoggerManager-specific branch
- map string log levels to integer logging levels for standard loggers
- add regression tests for skill discovery, LightAgent initialization, error logging, and LoggerManager compatibility

Fixes #61.

## Tests
- PYTHONPATH=. /Users/macpro/opt/anaconda3/envs/Langchain-Chatchat/bin/python -m pytest -q tests/test_skill_manager_logging.py tests/test_memory_policy.py tests/test_vector_memory_adapter_example.py tests/test_v065_core.py tests/test_guardrails.py tests/test_lightflow.py
- /Users/macpro/opt/anaconda3/envs/Langchain-Chatchat/bin/python -m compileall -q LightAgent tests/test_skill_manager_logging.py
- git diff --check