### PR TITLE
fix: preserve explicit LiteLLM drop_params

### DIFF
--- a/LightAgent/litellm_client.py
+++ b/LightAgent/litellm_client.py
@@ -26,7 +26,7 @@ class _LiteLLMCompletions:
             params['api_key'] = self._api_key
         if self._base_url:
             params['api_base'] = self._base_url
-        params['drop_params'] = True
+        params.setdefault('drop_params', True)
         return self._litellm.completion(**params)
 
 

--- a/tests/test_litellm_client.py
+++ b/tests/test_litellm_client.py
@@ -42,6 +42,25 @@ def test_litellm_client_forwards_openai_style_create_params():
     ]
 
 
+def test_litellm_client_preserves_explicit_drop_params():
+    fake_litellm = FakeLiteLLM()
+    client = LiteLLMClient(litellm_module=fake_litellm)
+
+    client.chat.completions.create(
+        model="openai/gpt-4o-mini",
+        messages=[{"role": "user", "content": "ping"}],
+        drop_params=False,
+    )
+
+    assert fake_litellm.calls == [
+        {
+            "model": "openai/gpt-4o-mini",
+            "messages": [{"role": "user", "content": "ping"}],
+            "drop_params": False,
+        }
+    ]
+
+
 def test_litellm_client_has_clear_optional_dependency_error(monkeypatch):
     original_import = builtins.__import__
 


### PR DESCRIPTION
## Summary
- preserve an explicit `drop_params` value when forwarding requests through `LiteLLMClient`
- keep the existing default behavior by setting `drop_params=True` only when callers do not provide it
- add a regression test for explicit `drop_params=False`

## Why
`LiteLLMClient` exposes an OpenAI-style `client.chat.completions.create(**params)` wrapper, but it previously overwrote any caller-provided `drop_params` value. This made it impossible for callers/tests to opt into LiteLLM's stricter parameter handling when needed.

## Validation
- `python -m compileall -q LightAgent`
- `PYTHONPATH=. python -m pytest -q tests/test_litellm_client.py`
- `PYTHONPATH=. python -m pytest -q tests/test_v065_core.py tests/test_v070_tracing.py tests/test_memory_policy.py`