### PR TITLE
fix: cap streaming tool-call loop with max retry

### DIFF
--- a/LightAgent/core.py
+++ b/LightAgent/core.py
@@ -1161,6 +1161,7 @@ class LightAgent:
         """流式处理逻辑"""
         for _ in range(max_retry):
             try:
+                tool_iterations = 0
                 # 处理当前响应（可能包含多轮工具调用）
                 while True:
                     # 初始化变量
@@ -1394,6 +1395,21 @@ class LightAgent:
 
                             # 如果调用了finish工具，则结束处理
                             if finish_called:
+                                return
+
+                            tool_iterations += 1
+                            if tool_iterations >= max_retry:
+                                error_msg = f"Max tool iterations({max_retry}) reached."
+                                self.log("ERROR", "max_tool_iterations_reached", {"message": error_msg})
+                                self._record_trace("error", {
+                                    "stage": "max_tool_iterations",
+                                    "error": error_msg,
+                                })
+                                self._record_trace("run_end", {
+                                    "success": False,
+                                    "error": "max_tool_iterations_reached",
+                                })
+                                yield error_msg
                                 return
 
                             # 准备下一轮请求

--- a/tests/test_v065_core.py
+++ b/tests/test_v065_core.py
@@ -49,6 +49,54 @@ class ToolCallCompletions:
         return SimpleNamespace(choices=[SimpleNamespace(message=message)])
 
 
+class LoopingStreamToolCallCompletions:
+    def __init__(self, max_create_calls):
+        self.calls = []
+        self.max_create_calls = max_create_calls
+
+    def create(self, **params):
+        self.calls.append(params)
+        if len(self.calls) > self.max_create_calls:
+            raise AssertionError("stream loop exceeded max_retry")
+
+        call_id = f"call_runtime_add_{len(self.calls)}"
+        return iter([
+            SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        delta=SimpleNamespace(
+                            reasoning_content=None,
+                            content=None,
+                            tool_calls=[
+                                SimpleNamespace(
+                                    index=0,
+                                    id=call_id,
+                                    function=SimpleNamespace(
+                                        name="runtime_add",
+                                        arguments=json.dumps({"a": 20, "b": 22}),
+                                    ),
+                                )
+                            ],
+                        ),
+                        finish_reason=None,
+                    )
+                ],
+            ),
+            SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        delta=SimpleNamespace(
+                            reasoning_content=None,
+                            content=None,
+                            tool_calls=None,
+                        ),
+                        finish_reason="tool_calls",
+                    )
+                ],
+            ),
+        ])
+
+
 class ErrorCompletions:
     def __init__(self, status_code):
         self.status_code = status_code
@@ -134,6 +182,20 @@ def test_stream_default_remains_generator_and_event_is_opt_in():
     assert isinstance(event, StreamEvent)
     assert event.type == "error"
     assert str(event.data).startswith("[LA-429]")
+
+
+def test_stream_tool_loop_stops_at_max_retry():
+    agent = make_agent()
+    completions = attach_client(agent, LoopingStreamToolCallCompletions(max_create_calls=2))
+
+    chunks = list(agent.run("loop", tools=[runtime_add], stream=True, max_retry=2, trace=True))
+
+    assert len(completions.calls) == 2
+    assert any("Max tool iterations(2) reached." in str(chunk) for chunk in chunks)
+    assert agent.export_trace()[-1]["data"] == {
+        "success": False,
+        "error": "max_tool_iterations_reached",
+    }
 
 
 def test_tool_parameter_validation_missing_required_and_wrong_type():


### PR DESCRIPTION
## Summary

- cap the streaming multi-tool-call loop with the existing `max_retry` limit
- emit a clear `Max tool iterations(n) reached.` message when the stream keeps requesting tools
- record `max_tool_iterations` error and failed `run_end` trace events
- add a regression test for a looping streaming tool-call response

## Why

The non-streaming path is already bounded by `max_retry`, but the streaming path had an inner `while True` that could continue requesting tools as long as the model kept emitting tool calls. This can burn tokens or budget under prompt injection, flaky tools, or oscillating tool decisions.

Fixes #70.

## Validation

- `python -m pytest tests -q`