### PR TITLE
Add Atlas Cloud provider example

### DIFF
--- a/docs/model_providers.md
+++ b/docs/model_providers.md
@@ -26,6 +26,34 @@ OpenRouter model names are provider-routed strings such as
 `openai/gpt-4.1`, `anthropic/claude-sonnet-4`, or another model listed in your
 OpenRouter account.
 
+### Atlas Cloud
+
+Atlas Cloud exposes an OpenAI-compatible `/v1` endpoint, so it works with the
+standard `LightAgent` client configuration. Keep the API key outside source
+control and pass it through `ATLASCLOUD_API_KEY`:
+
+```bash
+export ATLASCLOUD_API_KEY="your_atlascloud_api_key"
+```
+
+```python
+import os
+
+from LightAgent import LightAgent
+
+agent = LightAgent(
+    model="deepseek-ai/deepseek-v4-pro",
+    api_key=os.environ["ATLASCLOUD_API_KEY"],
+    base_url="https://api.atlascloud.ai/v1",
+)
+
+print(agent.run("Summarize LightAgent in one sentence."))
+```
+
+Use the exact model name from your Atlas Cloud account. If you choose a
+reasoning model, set a large enough output budget in your application request
+path so the model has room to return a final answer.
+
 ### vLLM
 
 Start vLLM with its OpenAI-compatible server, then use its `/v1` endpoint:

--- a/example/12.atlas_cloud.py
+++ b/example/12.atlas_cloud.py
@@ -1,0 +1,20 @@
+import os
+
+from LightAgent import LightAgent
+
+
+api_key = os.environ.get("ATLASCLOUD_API_KEY")
+if not api_key:
+    raise RuntimeError("Set ATLASCLOUD_API_KEY before running this example.")
+
+
+agent = LightAgent(
+    model=os.environ.get("ATLASCLOUD_MODEL", "deepseek-ai/deepseek-v4-pro"),
+    api_key=api_key,
+    base_url=os.environ.get("ATLASCLOUD_BASE_URL", "https://api.atlascloud.ai/v1"),
+    role="You are a concise assistant for LightAgent integration examples.",
+)
+
+
+response = agent.run("Explain how LightAgent connects to OpenAI-compatible providers.")
+print(response)


### PR DESCRIPTION
## Summary
- document Atlas Cloud as an OpenAI-compatible provider in the model provider guide
- add a runnable example that reads `ATLASCLOUD_API_KEY` and optional model/base URL overrides from the environment

## Compatibility
- [x] Existing `agent.run("hello")` behavior is unchanged, or the change is documented.
- [x] Existing `stream=True` behavior is unchanged, or the change is documented.

## Tests
- [x] `/Users/zby/.local/bin/python3.11 -m compileall -q LightAgent example/12.atlas_cloud.py`
- [x] `PYTHONPATH=. /tmp/atlas-work-20260707/lightagent-venv/bin/python -m pytest -q tests/test_v065_core.py tests/test_v070_tracing.py tests/test_memory_policy.py` (`29 passed`)

## Notes
No README sponsor/logo/credits changes. The example uses environment variables only and does not include any real API key.