### PR TITLE
docs: add ClawMem memory adapter example

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ For shared long-term memory or graph memory deployments, review the [Memory Secu
 
 For lightweight shared memory experiments, see [SharedMemoryPool](docs/shared_memory_pool.md).
 
+For optional ClawMem long-term memory adapter setup, see [ClawMem Memory Adapter](docs/clawmem_memory_adapter.md).
+
 For memory write admission, expiration-aware retrieval, and low-quality memory write blocking, see [Memory Admission And Mutation Controls](docs/memory_admission.md).
 
 For separating trace, user memory, self-reflection memory, and LightSwarm delegation state, see [Memory, Trace, And Swarm Boundaries](docs/memory_trace_swarm_boundaries.md).

--- a/docs/clawmem_memory_adapter.md
+++ b/docs/clawmem_memory_adapter.md
@@ -1,0 +1,121 @@
+## ClawMem Memory Adapter Example
+
+LightAgent can use ClawMem as an optional long-term memory backend through the
+same small `MemoryProtocol` used by other memory integrations:
+
+```python
+memory.store(data: str, user_id: str)
+memory.retrieve(query: str, user_id: str)
+```
+
+The example in `example/clawmem_memory_adapter.py` keeps ClawMem outside the
+core dependency set. It accepts an injected client, so applications can wrap a
+ClawMem HTTP client, SDK client, MCP client, or local service while tests use a
+fake client with no live network calls.
+
+### Adapter Shape
+
+`ClawMemMemoryAdapter` expects the injected client to expose two methods:
+
+```python
+client.create_memory(payload)
+client.search_memories(
+    query,
+    user_id=user_id,
+    limit=top_k,
+    metadata_filter={...},
+)
+```
+
+The adapter maps a LightAgent memory write to a ClawMem-style knowledge item:
+
+| LightAgent field | ClawMem payload field |
+| --- | --- |
+| `data` | `content` |
+| first line of `data` | `title` |
+| short text summary | `description` |
+| `user_id` | `user_id` |
+| `MemoryScope` metadata | `metadata` and searchable tags |
+
+Returned search results are normalized back to LightAgent's retrieval shape:
+
+```python
+{
+    "results": [
+        {
+            "memory": "Alice prefers quiet beach towns",
+            "score": 0.91,
+            "user_id": "tenant-a:alice",
+            "metadata": {
+                "source": "user",
+                "scope": "user",
+                "agent_name": "travel-agent",
+                "user_id": "tenant-a:alice",
+            },
+        }
+    ]
+}
+```
+
+### Minimal Usage
+
+```python
+from LightAgent import LightAgent, MemoryPolicy
+from example.clawmem_memory_adapter import ClawMemMemoryAdapter
+
+
+class MyClawMemClient:
+    def create_memory(self, payload):
+        # Call your ClawMem SDK, HTTP API, MCP tool, or local service here.
+        return {"id": "memory-id"}
+
+    def search_memories(self, query, *, user_id, limit, metadata_filter=None):
+        # Return ClawMem items with content/text, score, user_id, and metadata.
+        return []
+
+
+memory = ClawMemMemoryAdapter(MyClawMemClient(), agent_name="travel-agent")
+
+agent = LightAgent(
+    name="travel-agent",
+    model="gpt-4.1",
+    api_key="your_api_key",
+    base_url="your_base_url",
+    memory=memory,
+    memory_policy=MemoryPolicy(
+        namespace="tenant-a",
+        allow_unattributed_results=False,
+        allowed_sources=("user",),
+        allowed_scopes=("user",),
+        allowed_agent_names=("travel-agent",),
+    ),
+)
+```
+
+### Recommended Policy
+
+When ClawMem is shared across tenants, users, agents, or environments, keep
+retrieval fail-closed:
+
+```python
+MemoryPolicy(
+    namespace="prod-tenant-a",
+    allow_unattributed_results=False,
+    allowed_sources=("user",),
+    allowed_scopes=("user",),
+    allowed_agent_names=("travel-agent",),
+)
+```
+
+This ensures ClawMem records missing provenance, records from another user, and
+agent-private reflection memories are not injected into user-facing prompts.
+
+### Production Notes
+
+- Keep ClawMem dependencies optional and application-owned.
+- Do not commit ClawMem API keys or service URLs into examples.
+- Preserve `user_id`, `source`, `scope`, and `agent_name` metadata on both write
+  and read paths.
+- Use `memory_write_admission`, `reject_duplicate_writes`, and
+  `max_writes_per_run` for high-risk or high-volume deployments.
+- Use fake clients in tests so CI stays deterministic and offline.

--- a/example/clawmem_memory_adapter.py
+++ b/example/clawmem_memory_adapter.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+Minimal ClawMem memory adapter example.
+
+This file demonstrates how to connect a ClawMem-like client to LightAgent's
+small MemoryProtocol without adding ClawMem as a required dependency. The
+provided client is intentionally injected so tests and CI can use a fake client
+instead of making live network calls or requiring secrets.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+from LightAgent import LightAgent, MemoryPolicy, MemoryScope
+
+
+class ClawMemMemoryAdapter:
+    """MemoryProtocol adapter for a ClawMem-compatible client.
+
+    The injected client should expose:
+
+    - `create_memory(payload: dict[str, Any])`
+    - `search_memories(query: str, *, user_id: str, limit: int, metadata_filter: dict[str, Any] | None = None)`
+
+    Wrap the real ClawMem HTTP, MCP, or SDK client behind those two methods so
+    this adapter can stay dependency-free.
+    """
+
+    def __init__(
+            self,
+            client: Any,
+            *,
+            agent_name: str = "lightagent",
+            category: str = "lightagent",
+            top_k: int = 5,
+            default_source: str = "user",
+            default_scope: str = "user",
+    ):
+        if top_k <= 0:
+            raise ValueError("top_k must be greater than 0")
+        self.client = client
+        self.agent_name = agent_name
+        self.category = category
+        self.top_k = top_k
+        self.default_source = default_source
+        self.default_scope = default_scope
+
+    def store(self, data: str, user_id: str, metadata: dict[str, Any] | None = None) -> dict[str, Any]:
+        """Store a LightAgent memory as a ClawMem knowledge item."""
+        memory_text = str(data)
+        record_metadata = self._metadata(user_id=user_id, metadata=metadata)
+        payload = {
+            "title": self._title(memory_text),
+            "description": self._description(memory_text),
+            "content": memory_text,
+            "category": self.category,
+            "user_id": str(user_id),
+            "metadata": record_metadata,
+            "tags": self._tags(record_metadata),
+        }
+        created = self.client.create_memory(payload)
+        return {
+            "stored": True,
+            "user_id": str(user_id),
+            "memory_id": self._value(created, "id", "memory_id", "memoryId"),
+        }
+
+    def retrieve(self, query: str, user_id: str) -> dict[str, list[dict[str, Any]]]:
+        """Search ClawMem and return LightAgent-compatible memory results."""
+        metadata_filter = {
+            "source": self.default_source,
+            "scope": self.default_scope,
+            "agent_name": self.agent_name,
+        }
+        raw_results = self.client.search_memories(
+            str(query),
+            user_id=str(user_id),
+            limit=self.top_k,
+            metadata_filter=metadata_filter,
+        )
+
+        results = []
+        for item in raw_results or []:
+            memory = self._value(item, "memory", "content", "text")
+            if memory is None:
+                continue
+            item_metadata = self._value(item, "metadata") or {}
+            if not isinstance(item_metadata, dict):
+                item_metadata = {}
+            result_user_id = str(self._value(item, "user_id", "userId") or user_id)
+            item_metadata.setdefault("user_id", result_user_id)
+            item_metadata.setdefault("source", self.default_source)
+            item_metadata.setdefault("scope", self.default_scope)
+            item_metadata.setdefault("agent_name", self.agent_name)
+            results.append({
+                "memory": str(memory),
+                "score": self._value(item, "score"),
+                "user_id": result_user_id,
+                "metadata": item_metadata,
+            })
+        return {"results": results}
+
+    def _metadata(self, *, user_id: str, metadata: dict[str, Any] | None = None) -> dict[str, Any]:
+        record_metadata = MemoryScope(
+            source=self.default_source,
+            scope=self.default_scope,
+            agent_name=self.agent_name,
+            metadata={"user_id": str(user_id)},
+        ).to_metadata()
+        if metadata:
+            record_metadata.update(metadata)
+        record_metadata.setdefault("user_id", str(user_id))
+        record_metadata.setdefault("source", self.default_source)
+        record_metadata.setdefault("scope", self.default_scope)
+        record_metadata.setdefault("agent_name", self.agent_name)
+        return record_metadata
+
+    @staticmethod
+    def _title(text: str, *, max_length: int = 80) -> str:
+        title = " ".join((text.strip().splitlines() or [""])[0].split())
+        if not title:
+            return "LightAgent memory"
+        if len(title) <= max_length:
+            return title
+        return f"{title[:max_length - 3].rstrip()}..."
+
+    @classmethod
+    def _description(cls, text: str) -> str:
+        return cls._title(text, max_length=160)
+
+    @staticmethod
+    def _tags(metadata: dict[str, Any]) -> list[str]:
+        tags = [
+            f"source:{metadata.get('source')}",
+            f"scope:{metadata.get('scope')}",
+        ]
+        agent_name = metadata.get("agent_name")
+        if agent_name:
+            tags.append(f"agent:{agent_name}")
+        user_id = metadata.get("user_id")
+        if user_id:
+            tags.append(f"user:{user_id}")
+        return tags
+
+    @staticmethod
+    def _value(item: Any, *names: str) -> Any:
+        if item is None:
+            return None
+        if isinstance(item, dict):
+            for name in names:
+                if name in item:
+                    return item[name]
+            return None
+        for name in names:
+            if hasattr(item, name):
+                return getattr(item, name)
+        return None
+
+
+def build_agent(memory: ClawMemMemoryAdapter) -> LightAgent:
+    return LightAgent(
+        role="You are LightAgent with an optional ClawMem long-term memory adapter.",
+        model="deepseek-chat",
+        api_key="your_api_key",
+        base_url="your_base_url",
+        memory=memory,
+        memory_policy=MemoryPolicy(
+            namespace="demo",
+            allow_unattributed_results=False,
+            allowed_sources=("user",),
+            allowed_scopes=("user",),
+        ),
+        tree_of_thought=False,
+    )
+
+
+class ExampleClawMemClient:
+    """Tiny placeholder showing the methods the adapter expects.
+
+    Replace this with a wrapper around your ClawMem SDK, HTTP client, or MCP
+    client. The methods deliberately raise so the example never performs a live
+    network call unless the user supplies a real client.
+    """
+
+    def create_memory(self, payload: dict[str, Any]) -> dict[str, Any]:
+        raise NotImplementedError("Wrap your ClawMem client and create the memory item here.")
+
+    def search_memories(
+            self,
+            query: str,
+            *,
+            user_id: str,
+            limit: int,
+            metadata_filter: dict[str, Any] | None = None,
+    ) -> Iterable[dict[str, Any]]:
+        raise NotImplementedError("Wrap your ClawMem client and search memory items here.")
+
+
+if __name__ == "__main__":
+    client = ExampleClawMemClient()
+    memory = ClawMemMemoryAdapter(client, agent_name="travel-agent")
+    agent = build_agent(memory)
+
+    print(agent.run("Remember that I prefer quiet beach towns.", user_id="user_01"))
+    print(agent.run("Where should I travel next?", user_id="user_01"))

--- a/tests/test_clawmem_memory_adapter_example.py
+++ b/tests/test_clawmem_memory_adapter_example.py
@@ -1,0 +1,177 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+from LightAgent import LightAgent, MemoryPolicy
+
+
+def load_example_module():
+    example_path = Path(__file__).resolve().parents[1] / "example" / "clawmem_memory_adapter.py"
+    spec = importlib.util.spec_from_file_location("clawmem_memory_adapter_example", example_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakeClawMemClient:
+    def __init__(self):
+        self.created_payloads = []
+        self.search_calls = []
+        self.search_results = []
+
+    def create_memory(self, payload):
+        self.created_payloads.append(payload)
+        return {"id": f"memory-{len(self.created_payloads)}"}
+
+    def search_memories(self, query, *, user_id, limit, metadata_filter=None):
+        self.search_calls.append({
+            "query": query,
+            "user_id": user_id,
+            "limit": limit,
+            "metadata_filter": metadata_filter,
+        })
+        return self.search_results[:limit]
+
+
+class StaticCompletions:
+    def __init__(self, content="done"):
+        self.calls = []
+        self.content = content
+
+    def create(self, **params):
+        self.calls.append(params)
+        message = SimpleNamespace(content=self.content, tool_calls=None)
+        return SimpleNamespace(choices=[SimpleNamespace(message=message)])
+
+
+def test_clawmem_adapter_stores_memory_with_policy_metadata():
+    module = load_example_module()
+    client = FakeClawMemClient()
+    adapter = module.ClawMemMemoryAdapter(client, agent_name="travel-agent")
+
+    result = adapter.store(
+        "Alice prefers quiet beach towns",
+        user_id="tenant:alice",
+        metadata={
+            "source": "user",
+            "scope": "user",
+            "agent_name": "travel-agent",
+            "trace_id": "trace-1",
+            "original_user_id": "alice",
+        },
+    )
+
+    payload = client.created_payloads[0]
+    assert result == {"stored": True, "user_id": "tenant:alice", "memory_id": "memory-1"}
+    assert payload["title"] == "Alice prefers quiet beach towns"
+    assert payload["content"] == "Alice prefers quiet beach towns"
+    assert payload["user_id"] == "tenant:alice"
+    assert payload["metadata"]["source"] == "user"
+    assert payload["metadata"]["scope"] == "user"
+    assert payload["metadata"]["agent_name"] == "travel-agent"
+    assert payload["metadata"]["trace_id"] == "trace-1"
+    assert "source:user" in payload["tags"]
+    assert "scope:user" in payload["tags"]
+    assert "agent:travel-agent" in payload["tags"]
+
+
+def test_clawmem_adapter_returns_memory_policy_compatible_results():
+    module = load_example_module()
+    client = FakeClawMemClient()
+    client.search_results = [
+        {
+            "content": "Alice prefers quiet beach towns",
+            "score": 0.91,
+            "user_id": "tenant:alice",
+            "metadata": {
+                "source": "user",
+                "scope": "user",
+                "agent_name": "travel-agent",
+                "user_id": "tenant:alice",
+            },
+        }
+    ]
+    adapter = module.ClawMemMemoryAdapter(client, agent_name="travel-agent", top_k=3)
+
+    results = adapter.retrieve("quiet beach", user_id="tenant:alice")
+
+    assert client.search_calls == [{
+        "query": "quiet beach",
+        "user_id": "tenant:alice",
+        "limit": 3,
+        "metadata_filter": {
+            "source": "user",
+            "scope": "user",
+            "agent_name": "travel-agent",
+        },
+    }]
+    assert results["results"] == [{
+        "memory": "Alice prefers quiet beach towns",
+        "score": 0.91,
+        "user_id": "tenant:alice",
+        "metadata": {
+            "source": "user",
+            "scope": "user",
+            "agent_name": "travel-agent",
+            "user_id": "tenant:alice",
+        },
+    }]
+
+
+def test_clawmem_adapter_works_with_lightagent_memory_policy():
+    module = load_example_module()
+    client = FakeClawMemClient()
+    client.search_results = [
+        {
+            "content": "Alice prefers quiet beach towns",
+            "score": 0.95,
+            "user_id": "tenant:alice",
+            "metadata": {
+                "source": "user",
+                "scope": "user",
+                "agent_name": "travel-agent",
+                "user_id": "tenant:alice",
+            },
+        },
+        {
+            "content": "Reflection draft should stay private",
+            "score": 0.99,
+            "user_id": "tenant:alice",
+            "metadata": {
+                "source": "reflection",
+                "scope": "agent",
+                "agent_name": "travel-agent",
+                "user_id": "tenant:alice",
+            },
+        },
+    ]
+    memory = module.ClawMemMemoryAdapter(client, agent_name="travel-agent")
+    agent = LightAgent(
+        name="travel-agent",
+        model="gpt-4o-mini",
+        api_key="test-key",
+        base_url="http://127.0.0.1:9/v1",
+        memory=memory,
+        memory_policy=MemoryPolicy(
+            namespace="tenant",
+            allow_unattributed_results=False,
+            allowed_sources=("user",),
+            allowed_scopes=("user",),
+            allowed_agent_names=("travel-agent",),
+        ),
+        auto_discover_skills=False,
+    )
+    completions = StaticCompletions("done")
+    agent.client = SimpleNamespace(chat=SimpleNamespace(completions=completions))
+
+    result = agent.run("Where should I travel next?", user_id="alice", result_format="object", trace=True)
+
+    prompt = completions.calls[0]["messages"][-1]["content"]
+    assert result.content == "done"
+    assert "Alice prefers quiet beach towns" in prompt
+    assert "Reflection draft should stay private" not in prompt
+    assert client.created_payloads[0]["user_id"] == "tenant:alice"
+    assert client.created_payloads[0]["metadata"]["original_user_id"] == "alice"


### PR DESCRIPTION
## Summary

- add a dependency-free `ClawMemMemoryAdapter` example that satisfies LightAgent's `MemoryProtocol`
- document how LightAgent memory writes map to ClawMem-style knowledge items while preserving `MemoryScope` metadata
- add fake-client tests so the example is covered without live network calls, secrets, or a required ClawMem dependency

## Why

Issue #33 asks for an optional ClawMem-backed memory path that stays outside the core dependency set. This PR keeps the integration as an example/docs/test contribution: applications can wrap their ClawMem HTTP, MCP, SDK, or local client behind the tiny `create_memory` / `search_memories` surface while LightAgent continues to use `store(data, user_id)` and `retrieve(query, user_id)`.

Refs #33.

## Validation

- `python -m pytest -q tests/test_clawmem_memory_adapter_example.py` (`3 passed`)
- `python -m pytest -q tests/test_clawmem_memory_adapter_example.py tests/test_vector_memory_adapter_example.py tests/test_memory_policy.py tests/test_shared_memory_pool.py` (`23 passed`)
- `python -m pytest -q` (`69 passed`)
- `python -m compileall -q LightAgent example tests`
- `git diff --check`
