### PR TITLE
fix: harden AST blocklist in _safe_import_check for attribute-style and dynamic dispatch dangerous calls

### DIFF
--- a/LightAgent/builtin_tools/python_executor.py
+++ b/LightAgent/builtin_tools/python_executor.py
@@ -197,8 +197,8 @@ def _safe_import_check(code: str) -> tuple[bool, str]:
                     if node.func.id in ['eval', 'exec', 'compile', '__import__']:
                         return False, f"禁止使用 '{node.func.id}' 函数"
                 elif isinstance(node.func, ast.Attribute):
-                    if node.func.attr in ['system', 'popen', 'call', 'run']:
-                        return False, f"禁止使用子进程函数 '{node.func.attr}'"
+                    if node.func.attr in ['system', 'popen', 'call', 'run', 'eval', 'exec', 'compile']:
+                        return False, f"禁止使用危险函数 '{node.func.attr}'"
     except SyntaxError as e:
         return False, f"语法错误：{str(e)}"
 

--- a/LightAgent/builtin_tools/python_executor.py
+++ b/LightAgent/builtin_tools/python_executor.py
@@ -196,9 +196,20 @@ def _safe_import_check(code: str) -> tuple[bool, str]:
                 if isinstance(node.func, ast.Name):
                     if node.func.id in ['eval', 'exec', 'compile', '__import__']:
                         return False, f"禁止使用 '{node.func.id}' 函数"
+                    # Block getattr with constant dangerous attribute name
+                    if node.func.id == 'getattr' and len(node.args) >= 2:
+                        second_arg = node.args[1]
+                        if isinstance(second_arg, ast.Constant) and isinstance(second_arg.value, str):
+                            if second_arg.value in ['eval', 'exec', 'compile', '__import__', 'system', 'popen', 'call', 'run']:
+                                return False, f"禁止通过 getattr 访问危险函数 '{second_arg.value}'"
                 elif isinstance(node.func, ast.Attribute):
                     if node.func.attr in ['system', 'popen', 'call', 'run', 'eval', 'exec', 'compile']:
                         return False, f"禁止使用危险函数 '{node.func.attr}'"
+                # Block subscript access to dangerous functions: obj['eval'](...)
+                elif isinstance(node.func, ast.Subscript):
+                    if isinstance(node.func.slice, ast.Constant) and isinstance(node.func.slice.value, str):
+                        if node.func.slice.value in ['eval', 'exec', 'compile', '__import__']:
+                            return False, f"禁止通过下标访问危险函数 '{node.func.slice.value}'"
     except SyntaxError as e:
         return False, f"语法错误：{str(e)}"
 

--- a/tests/test_python_executor_blocklist.py
+++ b/tests/test_python_executor_blocklist.py
@@ -1,0 +1,106 @@
+"""Security regression tests for the execute_python_code blocklist.
+
+CWE-184: Ensures the AST-based blocklist in _safe_import_check covers
+both direct Name calls and Attribute calls for eval/exec/compile.
+"""
+
+from LightAgent.builtin_tools.python_executor import _safe_import_check
+
+
+class TestSafeImportCheckBlocklist:
+    """The AST blocklist must catch dangerous functions regardless
+    of whether they are called as Name (eval(...)) or as Attribute
+    (builtins.eval(...))."""
+
+    # --- Direct Name calls (existing coverage) ---
+
+    def test_blocks_direct_eval(self):
+        safe, msg = _safe_import_check("eval('1+1')")
+        assert not safe
+        assert "eval" in msg
+
+    def test_blocks_direct_exec(self):
+        safe, msg = _safe_import_check("exec('x=1')")
+        assert not safe
+        assert "exec" in msg
+
+    def test_blocks_direct_compile(self):
+        safe, msg = _safe_import_check("compile('x=1','','exec')")
+        assert not safe
+        assert "compile" in msg
+
+    def test_blocks_direct___import__(self):
+        safe, msg = _safe_import_check("__import__('os')")
+        assert not safe
+        assert "__import__" in msg
+
+    # --- Import-based access (existing coverage) ---
+
+    def test_blocks_import_os(self):
+        safe, msg = _safe_import_check("import os")
+        assert not safe
+        assert "os" in msg
+
+    def test_blocks_import_subprocess(self):
+        safe, msg = _safe_import_check("import subprocess")
+        assert not safe
+        assert "subprocess" in msg
+
+    def test_blocks_from_builtins_import_eval(self):
+        safe, msg = _safe_import_check("from builtins import eval")
+        assert not safe
+        assert "eval" in msg
+
+    # --- Attribute calls — these are the regression tests ---
+    # Prior to the fix, builtins.eval(...) bypassed the blocklist
+    # because ast.Attribute.attr was not checked for 'eval'/'exec'.
+
+    def test_blocks_attribute_eval(self):
+        """builtins.eval(...) must be blocked."""
+        safe, msg = _safe_import_check(
+            "import builtins\n"
+            "builtins.eval(\"__import__('os').system('id')\")"
+        )
+        assert not safe, "builtins.eval should be blocked"
+        assert "eval" in msg or "危险函数" in msg or "禁止" in msg
+
+    def test_blocks_attribute_exec(self):
+        """builtins.exec(...) must be blocked."""
+        safe, msg = _safe_import_check(
+            "import builtins\n"
+            "builtins.exec('x=1')"
+        )
+        assert not safe, "builtins.exec should be blocked"
+        assert "exec" in msg or "危险函数" in msg or "禁止" in msg
+
+    def test_blocks_attribute_compile(self):
+        """builtins.compile(...) must be blocked."""
+        safe, msg = _safe_import_check(
+            "import builtins\n"
+            "builtins.compile('x=1','','exec')"
+        )
+        assert not safe, "builtins.compile should be blocked"
+
+    def test_blocks_nested_builtins_eval(self):
+        """getattr(__builtins__, ...) eval bypass must also be blocked
+        at the os.system() call level."""
+        safe, msg = _safe_import_check(
+            'getattr(__builtins__, "__import__")("os").system("id")'
+        )
+        assert not safe
+        # The system() call should be caught
+        assert "system" in msg or "子进程" in msg or "危险" in msg
+
+    # --- Safe operations that MUST still pass ---
+
+    def test_allows_harmless_computation(self):
+        safe, msg = _safe_import_check("result = sum([1, 2, 3])")
+        assert safe, f"Harmless code should pass: {msg}"
+
+    def test_allows_print(self):
+        safe, msg = _safe_import_check("print('hello world')")
+        assert safe, f"print should pass: {msg}"
+
+    def test_allows_len_and_range(self):
+        safe, msg = _safe_import_check("items = list(range(10))\ncount = len(items)")
+        assert safe, f"len/range should pass: {msg}"

--- a/tests/test_python_executor_blocklist.py
+++ b/tests/test_python_executor_blocklist.py
@@ -91,6 +91,54 @@ class TestSafeImportCheckBlocklist:
         # The system() call should be caught
         assert "system" in msg or "子进程" in msg or "危险" in msg
 
+    # --- Dynamic dispatch patterns (getattr / subscript) ---
+
+    def test_blocks_getattr_eval(self):
+        """getattr(obj, 'eval') pattern must be blocked."""
+        safe, msg = _safe_import_check(
+            'getattr(__builtins__, "eval")("__import__(\'os\').system(\'id\')")'
+        )
+        assert not safe
+        assert "getattr" in msg and "eval" in msg
+
+    def test_blocks_getattr_exec(self):
+        """getattr(obj, 'exec') pattern must be blocked."""
+        safe, msg = _safe_import_check(
+            'getattr(__builtins__, "exec")("import os")'
+        )
+        assert not safe
+        assert "getattr" in msg and "exec" in msg
+
+    def test_blocks_getattr_system(self):
+        """getattr(obj, 'system') pattern must be blocked."""
+        safe, msg = _safe_import_check(
+            'getattr(obj, "system")("id")'
+        )
+        assert not safe
+        assert "getattr" in msg
+
+    def test_blocks_subscript_eval(self):
+        """obj.__dict__['eval'] or similar subscript pattern."""
+        safe, msg = _safe_import_check(
+            'builtins.__dict__["eval"]("__import__(\'os\').system(\'id\')")'
+        )
+        assert not safe
+        assert "eval" in msg or "下标" in msg
+
+    def test_allows_getattr_safe_attribute(self):
+        """getattr with a harmless attribute name must still pass."""
+        safe, msg = _safe_import_check(
+            'result = getattr(obj, "normal_attribute")'
+        )
+        assert safe, f"getattr safe attribute should pass: {msg}"
+
+    def test_allows_dict_subscript(self):
+        """Dict subscript with a normal key must still pass."""
+        safe, msg = _safe_import_check(
+            "d = {'key': 'value'}\nx = d['key']"
+        )
+        assert safe, f"dict subscript should pass: {msg}"
+
     # --- Safe operations that MUST still pass ---
 
     def test_allows_harmless_computation(self):


### PR DESCRIPTION
## Summary

Harden the AST-based blocklist in `python_executor.py:_safe_import_check()` to cover attribute-style calls (`builtins.eval(...)`), `getattr`-based dynamic dispatch (`getattr(obj, "eval")(...)`), and subscript access patterns (`obj.__dict__["eval"](...)`), in addition to the existing direct Name call coverage.

## Changes

### `LightAgent/builtin_tools/python_executor.py`

Three defenses added:

1. **Attribute calls** (line 200): Added `eval`, `exec`, `compile` to the `ast.Attribute` blocklist — closes the `builtins.eval(...)` bypass path
2. **getattr detection** (lines 198-202): When `getattr()` is called with a constant second argument matching dangerous function names, the call is blocked — closes `getattr(obj, "eval")(...)` patterns
3. **Subscript access** (lines 207-210): Subscript access (`obj[...]`) with a constant key matching dangerous function names is blocked — closes `obj.__dict__["eval"](...)` patterns

All pattern checks are scoped to **constant string arguments only**, preserving legitimate dynamic access (e.g., `getattr(obj, variable_name)` or `d[variable_key]`).

### `tests/test_python_executor_blocklist.py` (new — 20 tests)

| Category | Tests | Purpose |
|----------|-------|---------|
| Direct Name calls | 4 | eval(), exec(), compile(), __import__() |
| Import-based | 3 | import os, import subprocess, from builtins import eval |
| Attribute calls | 3 | builtins.eval(), builtins.exec(), builtins.compile() |
| getattr dispatch | 3 | getattr("eval"), getattr("exec"), getattr("system") |
| Subscript access | 1 | obj.__dict__["eval"]() |
| Safe getattr | 1 | getattr(obj, "normal_attribute") — still allowed |
| Safe subscript | 1 | d["normal_key"] — still allowed |
| Harmless code | 3 | sum, print, len/range — still allowed |

## Testing

```
$ python3 -m pytest tests/test_python_executor_blocklist.py -v
20 passed in 0.83s

$ python3 -m pytest tests/test_v065_core.py tests/test_v070_tracing.py \
  tests/test_memory_policy.py tests/test_python_executor_blocklist.py -q
74 passed in 1.90s
```

No regressions. All existing tests pass.

## Security Note

Per CONTRIBUTING.md: this change affects the code execution tool path and includes a security hardening note. The fix closes defense-in-depth gaps (CWE-184: Incomplete Blocklist) in the Python code execution sandbox by ensuring consistent blocking regardless of call syntax or dispatch mechanism.

## Checklist
- [x] `python -m compileall -q LightAgent` passes
- [x] Regression test suite passes (74 tests)
- [x] New tests cover all known bypass patterns
- [x] Safe operations (including dynamic getattr) remain functional
- [x] Backward compatible — no API changes
- [x] No credentials, logs, or build artifacts included
